### PR TITLE
Enable lazy loading for background images

### DIFF
--- a/angatti.html
+++ b/angatti.html
@@ -39,11 +39,11 @@
     
     <title>Angatti - Linha Premium | Emporio I Piatti</title>
 </head>
-<body>
+<body class="lazy-bg" data-bg="/assets/media/bgs/jordane-mathieu-k7VgPnWFcx8-unsplash.jpg" style="background-image:none;">
     <!-- Preloader -->
     <div class="preloader">
         <div class="preloader-logo">
-            <img src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
+            <img loading="lazy" src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
         </div>
     </div>
 
@@ -52,7 +52,7 @@
         <div class="container">
             <nav class="navbar">
                 <a href="/" class="logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                 </a>
                 
                 <div class="menu-toggle" id="mobile-menu">
@@ -85,7 +85,7 @@
     <!-- Hero Section -->
     <section class="page-hero">
         <div class="hero-content">
-            <img width="180px" src="/assets/media/logos/ANGATTI_logo.png" alt="">
+            <img loading="lazy" width="180px" src="/assets/media/logos/ANGATTI_logo.png" alt="">
             <p class="hero-subtitle">Linha Premium de Massas Artesanais</p>
             <div class="breadcrumb">
                 <a href="/">Home</a> > <span>Angatti</span>
@@ -141,7 +141,7 @@
                     </p>
                     
                     <div class="signature">
-                        <img src="/assets/media/logos/ANGATTI_logo.png" alt="Angatti">
+                        <img loading="lazy" src="/assets/media/logos/ANGATTI_logo.png" alt="Angatti">
                     </div>
                 </div>
             </div>
@@ -192,7 +192,7 @@
             <!-- Talharim de Aipim -->
             <div class="talharim-premium-card">
                 <div class="product-pouch">
-                    <img src="/assets/media/photos/linha-raiz/Talharim_Aipim.webp" alt="Talharim de Aipim" class="pouch-image">
+                    <img loading="lazy" src="/assets/media/photos/linha-raiz/Talharim_Aipim.webp" alt="Talharim de Aipim" class="pouch-image">
                 </div>
                 <div class="product-details">
                     <h3>Talharim de Aipim</h3>
@@ -214,7 +214,7 @@
             <!-- Talharim de Feijão Guandu -->
             <div class="talharim-premium-card">
                 <div class="product-pouch">
-                    <img src="/assets/media/photos/linha-raiz/Talharim_Feijão Guandu.webp" alt="Talharim de Feijão Guandu" class="pouch-image">
+                    <img loading="lazy" src="/assets/media/photos/linha-raiz/Talharim_Feijão Guandu.webp" alt="Talharim de Feijão Guandu" class="pouch-image">
                 </div>
                 <div class="product-details">
                     <h3>Talharim de Feijão Guandu</h3>
@@ -236,7 +236,7 @@
             <!-- Talharim de Taioba -->
             <div class="talharim-premium-card">
                 <div class="product-pouch">
-                    <img src="/assets/media/photos/linha-raiz/Talharim_Taioba.webp" alt="Talharim de Taioba" class="pouch-image">
+                    <img loading="lazy" src="/assets/media/photos/linha-raiz/Talharim_Taioba.webp" alt="Talharim de Taioba" class="pouch-image">
                 </div>
                 <div class="product-details">
                     <h3>Talharim de Taioba</h3>
@@ -272,7 +272,7 @@
             <div class="flour-item">
                 <div class="flour-visual">
                     <div class="flour-badge">Novidade</div>
-                    <img src="/assets/media/photos/linha-raiz/Farinha Aipim.webp" alt="Farinha de Aipim" class="flour-pack">
+                    <img loading="lazy" src="/assets/media/photos/linha-raiz/Farinha Aipim.webp" alt="Farinha de Aipim" class="flour-pack">
                     <div class="flour-bg-element"></div>
                 </div>
                 <div class="flour-details">
@@ -295,7 +295,7 @@
             <!-- Farinha de Batata Doce -->
             <div class="flour-item">
                 <div class="flour-visual">
-                    <img src="/assets/media/photos/linha-raiz/Farinha Batata-Doce.webp" alt="Farinha de Batata Doce" class="flour-pack">
+                    <img loading="lazy" src="/assets/media/photos/linha-raiz/Farinha Batata-Doce.webp" alt="Farinha de Batata Doce" class="flour-pack">
                     <div class="flour-bg-element"></div>
                 </div>
                 <div class="flour-details">
@@ -319,7 +319,7 @@
             <div class="flour-item">
                 <div class="flour-visual">
                     <div class="flour-badge">Mais Pedida</div>
-                    <img src="/assets/media/photos/linha-raiz/Farinha Banana Verde.webp" alt="Farinha de Banana Verde" class="flour-pack">
+                    <img loading="lazy" src="/assets/media/photos/linha-raiz/Farinha Banana Verde.webp" alt="Farinha de Banana Verde" class="flour-pack">
                     <div class="flour-bg-element"></div>
                 </div>
                 <div class="flour-details">
@@ -342,7 +342,7 @@
             <!-- Farinha de Feijão Guandu -->
             <div class="flour-item">
                 <div class="flour-visual">
-                    <img src="/assets/media/photos/linha-raiz/Farinha Feijao Guandu.webp" alt="Farinha de Feijão Guandu" class="flour-pack">
+                    <img loading="lazy" src="/assets/media/photos/linha-raiz/Farinha Feijao Guandu.webp" alt="Farinha de Feijão Guandu" class="flour-pack">
                     <div class="flour-bg-element"></div>
                 </div>
                 <div class="flour-details">
@@ -366,7 +366,7 @@
 </section>
 
     <!-- Mistura para Bolo Section -->
-    <section class="cake-mix-section">
+    <section class="cake-mix-section lazy-bg" data-bg="/assets/media/bgs/vaishnav-chogale-rihwcorYt-4-unsplash.jpg" style="background-image:none;">
         <div class="container">
             <div class="mix-container">
                 <div class="mix-content">
@@ -382,7 +382,7 @@
                     <!-- Mistura 1 -->
                     <div class="mix-product">
                         <div class="mix-badge">Faz 2 receitas</div>
-                        <img src="/assets/media/photos/linha-raiz/Mix Bolo Tradicional.webp" alt="Mistura para Bolo com Aipim">
+                        <img loading="lazy" src="/assets/media/photos/linha-raiz/Mix Bolo Tradicional.webp" alt="Mistura para Bolo com Aipim">
                         <h3>Mistura com Farinha de Aipim</h3>
                         <p>840g · Cód. 7898974404053</p>
                     </div>
@@ -390,7 +390,7 @@
                     <!-- Mistura 2 -->
                     <div class="mix-product">
                         <div class="mix-badge">Faz 2 receitas</div>
-                        <img src="/assets/media/photos/linha-raiz/Mix Bolo Feijao-Guandu .webp" alt="Mistura para Bolo com Guandu">
+                        <img loading="lazy" src="/assets/media/photos/linha-raiz/Mix Bolo Feijao-Guandu .webp" alt="Mistura para Bolo com Guandu">
                         <h3>Mistura com Farinha de Guandu</h3>
                         <p>840g · Cód. 7898974404046</p>
                     </div>
@@ -411,7 +411,7 @@
                 <!-- Produto 1 -->
                 <div class="gourmet-card">
                     <div class="gourmet-image">
-                        <img src="/assets/media/photos/linha-gourmet/bolinho-costela.webp" alt="Bolinho de Costela">
+                        <img loading="lazy" src="/assets/media/photos/linha-gourmet/bolinho-costela.webp" alt="Bolinho de Costela">
                     </div>
                     <div class="gourmet-details">
                         <h3>Bolinho de Costela</h3>
@@ -426,7 +426,7 @@
                 <!-- Produto 2 -->
                 <div class="gourmet-card">
                     <div class="gourmet-image">
-                        <img src="/assets/media/photos/linha-gourmet/croquete-carne.webp" alt="Croquete de Carne">
+                        <img loading="lazy" src="/assets/media/photos/linha-gourmet/croquete-carne.webp" alt="Croquete de Carne">
                     </div>
                     <div class="gourmet-details">
                         <h3>Croquete de Carne</h3>
@@ -440,7 +440,7 @@
                 <!--produto 3-->
                 <div class="gourmet-card">
                     <div class="gourmet-image">
-                        <img src="/assets/media/photos/linha-gourmet/quiche-queijo-aipim.webp" alt="Quiche de Queijo">
+                        <img loading="lazy" src="/assets/media/photos/linha-gourmet/quiche-queijo-aipim.webp" alt="Quiche de Queijo">
                     </div>
                     <div class="gourmet-details">
                         <h3>Quiche de Queijo com Farinha de Aipim</h3>
@@ -453,7 +453,7 @@
                 </div>
                 <div class="gourmet-card">
                     <div class="gourmet-image">
-                        <img src="/assets/media/photos/linha-gourmet/quiche-queijo-taioba.webp" alt="Quiche de Queijo">
+                        <img loading="lazy" src="/assets/media/photos/linha-gourmet/quiche-queijo-taioba.webp" alt="Quiche de Queijo">
                     </div>
                     <div class="gourmet-details">
                         <h3>Quiche de Queijo</h3>
@@ -466,7 +466,7 @@
                 </div>
                 <div class="gourmet-card">
                     <div class="gourmet-image">
-                        <img src="/assets/media/photos/linha-gourmet/panqueca-farinha-aipim.webp" alt="Panqueca de Farinha de Aipim">
+                        <img loading="lazy" src="/assets/media/photos/linha-gourmet/panqueca-farinha-aipim.webp" alt="Panqueca de Farinha de Aipim">
                     </div>
                     <div class="gourmet-details">
                         <h3>Panqueca de Farinha de Aipim</h3>
@@ -479,7 +479,7 @@
                 </div>
                 <div class="gourmet-card">
                     <div class="gourmet-image">
-                        <img src="/assets/media/photos/linha-gourmet/panqueca-taioba.webp" alt="Panqueca de Taioba">
+                        <img loading="lazy" src="/assets/media/photos/linha-gourmet/panqueca-taioba.webp" alt="Panqueca de Taioba">
                     </div>
                     <div class="gourmet-details">
                         <h3>Panqueca de Taioba</h3>
@@ -507,7 +507,7 @@
                 taioba
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/farinha de taioba.jpg" alt="Farinha Angatti">
+                        <img loading="lazy" src="/assets/media/photos/farinha de taioba.jpg" alt="Farinha Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Farinha de Taioba</h3>
@@ -517,7 +517,7 @@
                 </div>
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/talharim de taioba.jpg" alt="Farinha Angatti">
+                        <img loading="lazy" src="/assets/media/photos/talharim de taioba.jpg" alt="Farinha Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Talharim de Taioba</h3>
@@ -527,7 +527,7 @@
                 </div>
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/nhoque de taioba.jpg" alt="Nhoque Angatti">
+                        <img loading="lazy" src="/assets/media/photos/nhoque de taioba.jpg" alt="Nhoque Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Nhoque de Taioba</h3>
@@ -539,7 +539,7 @@
                 talharim
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/farinha de aipim.jpg" alt="Farinha Angatti">
+                        <img loading="lazy" src="/assets/media/photos/farinha de aipim.jpg" alt="Farinha Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Farinha de Aipim</h3>
@@ -549,7 +549,7 @@
                 </div>
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/talharim de aipim.jpeg" alt="Talharim Angatti">
+                        <img loading="lazy" src="/assets/media/photos/talharim de aipim.jpeg" alt="Talharim Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Talharim de Aipim</h3>
@@ -559,7 +559,7 @@
                 </div>
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/nhoque de aipim.jpeg" alt="Nhoque Angatti">
+                        <img loading="lazy" src="/assets/media/photos/nhoque de aipim.jpeg" alt="Nhoque Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Nhoque de Aipim</h3>
@@ -569,7 +569,7 @@
                 </div>
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/farinha de guandu.jpg" alt="Farinha Angatti">
+                        <img loading="lazy" src="/assets/media/photos/farinha de guandu.jpg" alt="Farinha Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Farinha de Guandu</h3>
@@ -579,7 +579,7 @@
                 </div>
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/talharim de guandu.jpg" alt="Talharim Angatti">
+                        <img loading="lazy" src="/assets/media/photos/talharim de guandu.jpg" alt="Talharim Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Talharim de Guandu</h3>
@@ -590,7 +590,7 @@
     
                 <div class="product-card">
                     <div class="product-image">
-                        <img src="/assets/media/photos/nhoque de guandu.jpeg" alt="Nhoque Angatti">
+                        <img loading="lazy" src="/assets/media/photos/nhoque de guandu.jpeg" alt="Nhoque Angatti">
                     </div>
                     <div class="product-info">
                         <h3>Nhoque de Guandu</h3>
@@ -608,7 +608,7 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-col footer-logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                     <p>Massas artesanais sem glúten, produzidas com paixão e ingredientes selecionados em Maricá/RJ.</p>
                     
                     <div class="footer-social">
@@ -676,6 +676,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>
     <script src="/assets/js/main.min.js"></script>
+    <script src="/engine/lazy-bg.js"></script>
     
     <!-- Scripts Adicionais para as Novas Seções -->
     <script>

--- a/assets/css/angatti.css
+++ b/assets/css/angatti.css
@@ -16,7 +16,6 @@
 }
 
 body{
-    background-image: url('/assets/media/bgs/jordane-mathieu-k7VgPnWFcx8-unsplash.jpg');
     background-color: #f8f5f03f; /* Cor de fallback */
     background-position-y: 90%;
 }
@@ -514,7 +513,6 @@ body::before {
 .cake-mix-section {
     padding: 5rem 0;
     background: linear-gradient(to right, #fff 50%, #fcf8f3 50%);
-    background-image: url(/assets/media/bgs/vaishnav-chogale-rihwcorYt-4-unsplash.jpg);
     background-size: cover;
     background-position: right;
 }

--- a/assets/css/main.min.css
+++ b/assets/css/main.min.css
@@ -21,7 +21,6 @@ body {
     font-family: var(--font-secondary);
     color: var(--dark-color);
     background-color: #f8f5f03b; /* Cor de fallback */
-    background-image: url('/assets/media/bgs/hero-bg.webp');
     background-attachment: fixed;
     background-size: cover;
     background-position: center;
@@ -100,7 +99,6 @@ body::before {
     z-index: 10;
     opacity: 1 !important; /* Forçar visibilidade */
     transform: none !important; /* Prevenir transformações que possam esconder o conteúdo */
-    background-image: url('/assets/media/bgs/mp-bg.webp');
     background-attachment: fixed;
     background-size: cover;
     background-position: center;

--- a/engine/lazy-bg.js
+++ b/engine/lazy-bg.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded',function(){
+  const lazyBgs=[...document.querySelectorAll('[data-bg]')];
+  if('IntersectionObserver' in window){
+    const obs=new IntersectionObserver(entries=>{
+      entries.forEach(e=>{
+        if(e.isIntersecting){
+          const el=e.target;
+          el.style.backgroundImage=`url('${el.dataset.bg}')`;
+          el.removeAttribute('data-bg');
+          obs.unobserve(el);
+        }
+      });
+    });
+    lazyBgs.forEach(el=>obs.observe(el));
+  }else{
+    lazyBgs.forEach(el=>{
+      el.style.backgroundImage=`url('${el.dataset.bg}')`;
+      el.removeAttribute('data-bg');
+    });
+  }
+});

--- a/faleconosco.html
+++ b/faleconosco.html
@@ -38,11 +38,11 @@
     
     <title>Fale Conosco | Emporio I Piatti</title>
 </head>
-<body>
+<body class="lazy-bg" data-bg="/assets/media/bgs/hero-bg.webp" style="background-image:none;">
     <!-- Preloader -->
     <div class="preloader">
         <div class="preloader-logo">
-            <img src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
+            <img loading="lazy" src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
         </div>
     </div>
 
@@ -51,7 +51,7 @@
         <div class="container">
             <nav class="navbar">
                 <a href="/" class="logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                 </a>
                 
                 <div class="menu-toggle" id="mobile-menu">
@@ -83,7 +83,7 @@
 
     <!-- Hero Section -->
     <section class="page-hero">
-        <div class="hero-image" style="background-image: url('/assets/media/photos/contact-hero.jpg');">
+        <div class="hero-image lazy-bg" data-bg='/assets/media/photos/contact-hero.jpg' style='background-image:none;'>
             <div class="hero-overlay"></div>
         </div>
         
@@ -218,7 +218,7 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-col footer-logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                     <p>Massas artesanais sem glúten, produzidas com paixão e ingredientes selecionados em Maricá/RJ.</p>
                     
                     <div class="footer-social">
@@ -287,6 +287,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>
     <script src="/assets/js/main.min.js"></script>
+    <script src="/engine/lazy-bg.js"></script>
     
     <script>
         // Form submission

--- a/index.html
+++ b/index.html
@@ -38,11 +38,11 @@
     
     <title>Emporio I Piatti - Massas Artesanais Premium</title>
 </head>
-<body>
+<body class="lazy-bg" data-bg="/assets/media/bgs/hero-bg.webp" style="background-image:none;">
     <!-- Preloader -->
     <div class="preloader">
         <div class="preloader-logo">
-            <img src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
+            <img loading="lazy" src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
         </div>
     </div>
 
@@ -51,7 +51,7 @@
         <div class="container">
             <nav class="navbar">
                 <a href="/" class="logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                     
                 </a>
                 
@@ -92,7 +92,7 @@
         </div>
         
         <div class="hero-content">
-            <img width="300px" src="/assets/media/logos/logo_emporio.png" alt="">
+            <img loading="lazy" width="300px" src="/assets/media/logos/logo_emporio.png" alt="">
             <p class="hero-subtitle">Feitas com ingredientes selecionados da agricultura familiar</p>
             <a href="/angatti.html#secaoproduto" class="btn btn-primary">Conheça Nossos Produtos</a>
         </div>
@@ -114,7 +114,7 @@
             <div class="certifications-grid">
                 <div class="certification-card">
                     <div class="certification-icon">
-                        <img src="/assets/media/selos/selo_gluten.png" alt="Sem Glúten">
+                        <img loading="lazy" src="/assets/media/selos/selo_gluten.png" alt="Sem Glúten">
                     </div>
                     <h3>Sem Glúten</h3>
                     <p>Nossos produtos são cuidadosamente produzidos sem glúten, garantindo qualidade e sabor para todos.</p>
@@ -122,7 +122,7 @@
                 
                 <div class="certification-card">
                     <div class="certification-icon">
-                        <img src="/assets/media/selos/selo_agricultura.png" alt="Agricultura Familiar">
+                        <img loading="lazy" src="/assets/media/selos/selo_agricultura.png" alt="Agricultura Familiar">
                     </div>
                     <h3>Agricultura Familiar</h3>
                     <p>Valorizamos a produção local, utilizando insumos diretamente da agricultura familiar da região.</p>
@@ -130,7 +130,7 @@
                 
                 <div class="certification-card">
                     <div class="certification-icon">
-                        <img src="/assets/media/selos/selo_inspecao.png" alt="Selo SIM Maricá">
+                        <img loading="lazy" src="/assets/media/selos/selo_inspecao.png" alt="Selo SIM Maricá">
                     </div>
                     <h3>Selo SIM Maricá</h3>
                     <p>Certificados com o Selo de Inspeção Municipal, garantindo padrões de qualidade e segurança alimentar.</p>
@@ -140,7 +140,7 @@
     </section>
 
     <!-- Featured Product -->
-    <section class="featured-product">
+    <section class="featured-product lazy-bg" data-bg="/assets/media/bgs/mp-bg.webp" style="background-image:none;">
         <div class="container">
             <div class="product-content">
                 <h2 class="product-title">Angatti</h2>
@@ -155,7 +155,7 @@
             
             <div class="product-image">
                 <a href="/angatti.html">
-                    <img src="/assets/media/logos/ANGATTI_logo.png" alt="Linha Angatti" class="product-img">
+                    <img loading="lazy" src="/assets/media/logos/ANGATTI_logo.png" alt="Linha Angatti" class="product-img">
                 </a>
                 <div class="product-bg"></div>
             </div>
@@ -222,7 +222,7 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-col footer-logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                     <p>Massas artesanais sem glúten, produzidas com paixão e ingredientes selecionados em Maricá/RJ.</p>
                     
                     <div class="footer-social">
@@ -291,5 +291,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>
     <script src="/assets/js/main.min.js"></script>
+    <script src="/engine/lazy-bg.js"></script>
 </body>
 </html>

--- a/noticias.html
+++ b/noticias.html
@@ -38,12 +38,12 @@
     
     <title>Notícias | Emporio I Piatti</title>
 </head>
-<body>
+<body class="lazy-bg" data-bg="/assets/media/bgs/hero-bg.webp" style="background-image:none;">
     <!-- Preloader -->
      <!---->
     <div class="preloader">
         <div class="preloader-logo">
-            <img src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
+            <img loading="lazy" src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
         </div>
     </div>
 
@@ -52,7 +52,7 @@
         <div class="container">
             <nav class="navbar">
                 <a href="/" class="logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                 </a>
                 
                 <div class="menu-toggle" id="mobile-menu">
@@ -84,7 +84,7 @@
 
     <!-- Hero Section -->
     <section class="page-hero">
-        <div class="hero-image" style="background-image: url('/assets/media/photos/news-hero.jpg');">
+        <div class="hero-image lazy-bg" data-bg='/assets/media/photos/news-hero.jpg' style='background-image:none;'>
             <div class="hero-overlay"></div>
         </div>
         
@@ -103,7 +103,7 @@
             <div class="news-grid">
                 <div class="news-card" data-link="https://www.marica.rj.gov.br/noticia/alimentos-produzidos-no-programa-bem-viver-alimentar-poderao-ter-selo-de-inspecao-municipal/">
                     <div class="news-image">
-                        <img src="/assets/media/photos/noticias/01.webp" alt="Notícia 1">
+                        <img loading="lazy" src="/assets/media/photos/noticias/01.webp" alt="Notícia 1">
                     </div>
                     <div class="news-content">
                         <h3>Alimentos produzidos no Programa Bem-viver Alimentar poderão ter selo de inspeção municipal</h3>
@@ -116,7 +116,7 @@
                 
                 <div class="news-card" data-link="https://www.marica.rj.gov.br/noticia/bem-viver-alimentar-disponibiliza-60-quilos-de-nhoque-de-taioba-ao-restaurante-municipal/">
                     <div class="news-image">
-                        <img src="/assets/media/photos/noticias/02.webp" alt="Notícia 2">
+                        <img loading="lazy" src="/assets/media/photos/noticias/02.webp" alt="Notícia 2">
                     </div>
                     <div class="news-content">
                         <h3>Bem-viver Alimentar disponibiliza 60 quilos de nhoque de taioba ao Restaurante Municipal</h3>
@@ -129,7 +129,7 @@
                 
                 <div class="news-card" data-link="https://www.marica.rj.gov.br/noticia/apresentacao-do-programa-bem-viver-alimentar-marca-segundo-dia-da-feira-das-profissoes/">
                     <div class="news-image">
-                        <img src="/assets/media/photos/noticias/03.webp" alt="Notícia 3">
+                        <img loading="lazy" src="/assets/media/photos/noticias/03.webp" alt="Notícia 3">
                     </div>
                     <div class="news-content">
                         <h3>Apresentação do Programa Bem-viver Alimentar marca segundo dia da Feira das Profissões</h3>
@@ -143,7 +143,7 @@
                 
                     <div class="news-card" data-link="https://extra.globo.com/rio/cidades/marica/noticia/2023/10/em-marica-emporio-recebe-selo-de-inspecao-municipal-por-produzir-alimentos-sem-gluten.ghtml">
                         <div class="news-image">
-                            <img src="/assets/media/photos/noticias/04.webp" alt="Notícia 4">
+                            <img loading="lazy" src="/assets/media/photos/noticias/04.webp" alt="Notícia 4">
                         </div>
                         <div class="news-content">
                             <h3>Em Maricá, empório recebe selo de inspeção municipal por produzir alimentos sem glúten</h3>
@@ -157,7 +157,7 @@
                 
                 <div class="news-card" data-link="https://www.marica.rj.gov.br/noticia/bem-viver-alimentar-recebe-primeiro-selo-de-inspecao-municipal-sim/">
                     <div class="news-image">
-                        <img src="/assets/media/photos/noticias/05.webp" alt="Notícia 5">
+                        <img loading="lazy" src="/assets/media/photos/noticias/05.webp" alt="Notícia 5">
                     </div>
                     <div class="news-content">
                         <h3>Bem-viver Alimentar recebe primeiro Selo de Inspeção Municipal (SIM)</h3>
@@ -177,7 +177,7 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-col footer-logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                     <p>Massas artesanais sem glúten, produzidas com paixão e ingredientes selecionados em Maricá/RJ.</p>
                     
                     <div class="footer-social">
@@ -246,5 +246,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>
     <script src="/assets/js/main.min.js"></script>
+    <script src="/engine/lazy-bg.js"></script>
 </body>
 </html>

--- a/parcerias.html
+++ b/parcerias.html
@@ -38,11 +38,11 @@
     
     <title>Parcerias | Emporio I Piatti</title>
 </head>
-<body>
+<body class="lazy-bg" data-bg="/assets/media/bgs/hero-bg.webp" style="background-image:none;">
     <!-- Preloader -->
     <div class="preloader">
         <div class="preloader-logo">
-            <img src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
+            <img loading="lazy" src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
         </div>
     </div>
 
@@ -51,7 +51,7 @@
         <div class="container">
             <nav class="navbar">
                 <a href="/" class="logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                 </a>
                 
                 <div class="menu-toggle" id="mobile-menu">
@@ -83,7 +83,7 @@
 
     <!-- Hero Section -->
     <section class="page-hero">
-        <div class="hero-image" style="background-image: url('/assets/media/photos/partners-hero.jpg');">
+        <div class="hero-image lazy-bg" data-bg='/assets/media/photos/partners-hero.jpg' style='background-image:none;'>
             <div class="hero-overlay"></div>
         </div>
         
@@ -113,7 +113,7 @@
             <div class="partners-grid">
                 <div class="partner-card">
                     <div class="partner-logo">
-                        <img src="/assets/media/logos/logo_bemviver.png" alt="Projeto Bem-viver Alimentar">
+                        <img loading="lazy" src="/assets/media/logos/logo_bemviver.png" alt="Projeto Bem-viver Alimentar">
                     </div>
                     <div class="partner-info">
                         <h3>Projeto Bem-viver Alimentar</h3>
@@ -124,7 +124,7 @@
                 
                 <div class="partner-card">
                     <div class="partner-logo">
-                        <img src="/assets/media/logos/logo_ictim.png" alt="ICTIM">
+                        <img loading="lazy" src="/assets/media/logos/logo_ictim.png" alt="ICTIM">
                     </div>
                     <div class="partner-info">
                         <h3>ICTIM</h3>
@@ -135,7 +135,7 @@
                 
                 <div class="partner-card">
                     <div class="partner-logo">
-                        <img src="/assets/media/logos/Logo_marica.png" alt="Prefeitura de Maricá">
+                        <img loading="lazy" src="/assets/media/logos/Logo_marica.png" alt="Prefeitura de Maricá">
                     </div>
                     <div class="partner-info">
                         <h3>Prefeitura de Maricá</h3>
@@ -152,7 +152,7 @@
                 
                 <div class="partner-single">
                     <div class="partner-logo">
-                        <img src="/assets/media/logos/logo_fapur.png" alt="FAPUR">
+                        <img loading="lazy" src="/assets/media/logos/logo_fapur.png" alt="FAPUR">
                     </div>
                     <div class="partner-info">
                         <h3>FAPUR</h3>
@@ -224,7 +224,7 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-col footer-logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                     <p>Massas artesanais sem glúten, produzidas com paixão e ingredientes selecionados em Maricá/RJ.</p>
                     
                     <div class="footer-social">
@@ -293,5 +293,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>
     <script src="/assets/js/main.min.js"></script>
+    <script src="/engine/lazy-bg.js"></script>
 </body>
 </html>

--- a/sobrenos.html
+++ b/sobrenos.html
@@ -38,11 +38,11 @@
     
     <title>Sobre Nós | Emporio I Piatti</title>
 </head>
-<body>
+<body class="lazy-bg" data-bg="/assets/media/bgs/hero-bg.webp" style="background-image:none;">
     <!-- Preloader -->
     <div class="preloader">
         <div class="preloader-logo">
-            <img src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
+            <img loading="lazy" src="/assets/media/logos/logo_emporio.png" alt="Emporio I Piatti">
         </div>
     </div>
 
@@ -51,7 +51,7 @@
         <div class="container">
             <nav class="navbar">
                 <a href="/" class="logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                 </a>
                 
                 <div class="menu-toggle" id="mobile-menu">
@@ -83,7 +83,7 @@
 
     <!-- Hero Section -->
     <section class="page-hero">
-        <div class="hero-image" style="background-image: url('/assets/media/photos/sobre-hero.jpg');">
+        <div class="hero-image lazy-bg" data-bg='/assets/media/photos/sobre-hero.jpg' style='background-image:none;'>
             <div class="hero-overlay"></div>
         </div>
         
@@ -106,7 +106,7 @@
             
             <div class="about-grid">
                 <div class="about-image">
-                    <img src="/assets/media/photos/talharim_pesto.jpeg" alt="Empório I Piatti" class="rounded-image">
+                    <img loading="lazy" src="/assets/media/photos/talharim_pesto.jpeg" alt="Empório I Piatti" class="rounded-image">
                     <div class="image-decor"></div>
                 </div>
                 
@@ -208,7 +208,7 @@
                 </div>
                 
                 <div class="quality-image">
-                    <img src="/assets/media/photos/talharim de guandu.jpg" alt="Controle de Qualidade" class="rounded-image">
+                    <img loading="lazy" src="/assets/media/photos/talharim de guandu.jpg" alt="Controle de Qualidade" class="rounded-image">
                 </div>
             </div>
         </div>
@@ -223,7 +223,7 @@
             <div class="ceo-grid">
                 <div class="ceo-image-wrapper">
                     <div class="ceo-image">
-                        <img src="/assets/media/photos/placeholder-ceo.jpg" alt="[Nome da CEO], Fundadora do Empório I Piatti">
+                        <img loading="lazy" src="/assets/media/photos/placeholder-ceo.jpg" alt="[Nome da CEO], Fundadora do Empório I Piatti">
                     </div>
                     <div class="ceo-image-decor"></div>
                 </div>
@@ -252,7 +252,7 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-col footer-logo">
-                    <img src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
+                    <img loading="lazy" src="/assets/media/logos/Logo2_emporio_IPIATTI.png" alt="Emporio I Piatti">
                     <p>Massas artesanais sem glúten, produzidas com paixão e ingredientes selecionados em Maricá/RJ.</p>
                     
                     <div class="footer-social">
@@ -321,6 +321,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>
     <script src="/assets/js/main.min.js"></script>
+    <script src="/engine/lazy-bg.js"></script>
     
     <script>
         // Tab functionality


### PR DESCRIPTION
## Summary
- convert CSS backgrounds to lazy-load via `data-bg`
- add small script to load background images with IntersectionObserver
- hook new script into all pages and remove background URLs from CSS

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68870a4b5df483288eb916bae982d664